### PR TITLE
Bug fix, cancel all orders should use old bitstamp API

### DIFF
--- a/lib/Bitstamp.js
+++ b/lib/Bitstamp.js
@@ -18,7 +18,7 @@ const HTTP_METHOD = {
 
 class Bitstamp {
 
-    constructor(opts = {}, base = "https://www.bitstamp.net/api/v2", 
+    constructor(opts = {}, base = "https://www.bitstamp.net/api/v2",
         old = "https://www.bitstamp.net/api"){
 
         this.base = base;
@@ -132,7 +132,7 @@ class Bitstamp {
             totalCallsMade: this.totalCallsMade
         };
     }
-    
+
     /* API */
 
     ticker(currency = null){
@@ -160,7 +160,7 @@ class Bitstamp {
     }
 
     conversionRate(){
-        
+
         const ep = "eur_usd";
         return this.call(this._resolveEP(ep, null), HTTP_METHOD.GET, null, false);
     }
@@ -174,44 +174,44 @@ class Bitstamp {
     }
 
     userTransaction(currency = null, opts = {}){
-        
+
         const ep = "user_transactions";
         //opts // {offset, limit, sort}
         return this.call(this._resolveEP(ep, currency), HTTP_METHOD.POST, opts || {}, true);
     }
 
     openOrders(currency = null){
-        
+
         const ep = "open_orders";
         return this.call(this._resolveEP(ep, currency), HTTP_METHOD.POST, {}, true);
     }
 
     openOrdersAll(){
-        
+
         const ep = "open_orders";
         return this.call(this._resolveEP(ep, "all/"), HTTP_METHOD.POST, {}, true);
     }
-    
+
     orderStatus(id){
-        
+
         const ep = "order_status";
         return this.call(this._resolveEP(ep, null), HTTP_METHOD.POST, {id}, true);
     }
 
     cancelOrder(id){
-        
+
         const ep = "cancel_order";
         return this.call(this._resolveEP(ep, null), HTTP_METHOD.POST, {id}, true);
     }
 
     cancelOrdersAll(){
-        
+
         const ep = "cancel_all_orders";
-        return this.call(this._resolveEP(ep, null), HTTP_METHOD.POST, {}, true);
+        return this.call(this._resolveEP(ep, null), HTTP_METHOD.POST, {}, true, true);
     }
-    
+
     buyLimitOrder(amount, price, currency = null, limit_price = null, daily_order = null){
-        
+
         const ep = "buy";
         const body = {
             amount,
@@ -223,16 +223,16 @@ class Bitstamp {
     }
 
     buyMarketOrder(amount, currency = null){
-        
+
         const ep = "buy/market";
         const body = {
             amount
         };
         return this.call(this._resolveEP(ep, currency), HTTP_METHOD.POST, body, true);
     }
-    
+
     sellLimitOrder(amount, price, currency = null, limit_price = null, daily_order = null){
-        
+
         const ep = "sell";
         const body = {
             amount,
@@ -244,7 +244,7 @@ class Bitstamp {
     }
 
     sellMarketOrder(amount, currency = null){
-        
+
         const ep = "sell/market";
         const body = {
             amount
@@ -255,13 +255,13 @@ class Bitstamp {
     /* OTHER */
 
     withDrawalRequests(timedelta = null){
-        
+
         const ep = "withdrawal_requests";
         return this.call(this._resolveEP(ep, null), HTTP_METHOD.POST, {timedelta}, true, true);
     }
 
     bitcoinWithdrawal(amount, address, instant = 0){
-        
+
         const ep = "bitcoin_withdrawal";
         const body = {
             amount,
@@ -272,7 +272,7 @@ class Bitstamp {
     }
 
     litecoinWithdrawal(amount, address){
-        
+
         const ep = "ltc_withdrawal";
         const body = {
             amount,
@@ -282,7 +282,7 @@ class Bitstamp {
     }
 
     ethereumWithdrawal(amount, address){
-        
+
         const ep = "eth_withdrawal";
         const body = {
             amount,
@@ -292,7 +292,7 @@ class Bitstamp {
     }
 
     rippleWithdrawal(amount, address, currency){
-        
+
         const ep = "ripple_withdrawal";
         const body = {
             amount,
@@ -303,7 +303,7 @@ class Bitstamp {
     }
 
     xrpWithdrawal(amount, address, destination_tag = null){
-        
+
         const ep = "xrp_withdrawal";
         const body = {
             amount,
@@ -314,19 +314,19 @@ class Bitstamp {
     }
 
     ethereumDepositAdress(){
-        
+
         const ep = "eth_address";
         return this.call(this._resolveEP(ep, null), HTTP_METHOD.POST, {}, true);
     }
 
     xrpDepositAdress(){
-        
+
         const ep = "xrp_address";
         return this.call(this._resolveEP(ep, null), HTTP_METHOD.POST, {}, true);
     }
 
     litecoinDepositAdress(){
-        
+
         const ep = "ltc_address";
         return this.call(this._resolveEP(ep, null), HTTP_METHOD.POST, {}, true);
     }
@@ -338,7 +338,7 @@ class Bitstamp {
     }
 
     rippleDepositAdress(){
-        
+
         const ep = "ripple_address";
         return this.call(this._resolveEP(ep, null), HTTP_METHOD.POST, {}, true, true);
     }
@@ -361,7 +361,7 @@ class Bitstamp {
     }
 
     transferMainToSub(amount, currency, subAccount = null){
-        
+
         const ep = "transfer-from-main";
         const body = {
             amount,
@@ -384,7 +384,7 @@ class Bitstamp {
     }
 
     cancelBankWithdrawal(id){
-        
+
         const ep = "withdrawal/cancel/";
         return this.call(this._resolveEP(ep, null), HTTP_METHOD.POST, {id}, true);
     }
@@ -396,7 +396,7 @@ class Bitstamp {
     }
 
     liquidationAddressInfo(address){
-        
+
         const ep = "liquidation_address/new";
         return this.call(this._resolveEP(ep, null), HTTP_METHOD.POST, {address}, true);
     }


### PR DESCRIPTION
While using your repo, found a bug. The cancell all open orders HTTP api should use the old one.

Hope it can help :+1: 