### PR TITLE
Missing "{" error while using node-bitstamp

### DIFF
--- a/lib/Bitstamp.js
+++ b/lib/Bitstamp.js
@@ -98,7 +98,7 @@ class Bitstamp {
                 
                 // The HTTP request worked but returned an error code.
                 // e.g. 401 unauthorized
-                if (response.statusCode < 200 || response.statusCode > 299)
+                if (response.statusCode < 200 || response.statusCode > 299) {
                     return reject(new Error(body));
                 }
 


### PR DESCRIPTION
There is a typo in code. Missing '{' at line 101. This breaks the library.