### PR TITLE
Adding live_orders stream to websocket feed

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const TickerStream = require("./lib/streams/TickerStream.js");
 const OrderBookStream = require("./lib/streams/OrderBookStream.js");
+const LiveOrderStream = require("./lib/streams/LiveOrderStream.js");
 
 const Bitstamp = require("./lib/Bitstamp.js");
 const CURRENCY = require("./lib/currency.js");
@@ -10,6 +11,7 @@ module.exports = {
     default: Bitstamp,
     TickerStream,
     OrderBookStream,
+    LiveOrderStream,
     Bitstamp,
     CURRENCY
 };

--- a/lib/streams/LiveOrderStream.js
+++ b/lib/streams/LiveOrderStream.js
@@ -1,0 +1,51 @@
+"use strict";
+
+const EventEmitter = require("events");
+const Pusher = require("pusher-js/node");
+
+class LiveOrderStream extends EventEmitter {
+
+    constructor(key = "de504dc5763aeef9ff52", cluster= "mt1", encrypted = true){
+        super();
+
+        this.key = key;
+        this.socket = new Pusher(this.key, {
+            cluster,
+            encrypted
+        });
+
+        this.socket.connection.bind("connected", () => {
+            super.emit("connected");
+        });
+
+        this.socket.connection.bind("disconnected", () => {
+            super.emit("disconnected");
+        });
+    }
+
+    subscribe(currency, topic = "live_orders", event = ["order_created","order_changed","order_deleted"]){
+        const key = currency ? `${topic}_${currency}` : topic;
+        const subscription = this.socket.subscribe(key);
+        subscription.bind(event[0], data => {
+            const {amount, price} = data;
+            super.emit(key, Object.assign({}, data, {currency, 'event': event[0]}));
+        });
+        subscription.bind(event[1], data => {
+            const {amount, price} = data;
+            super.emit(key, Object.assign({}, data, {currency, 'event': event[1]}));
+        });
+        subscription.bind(event[2], data => {
+            const {amount, price} = data;
+            super.emit(key, Object.assign({}, data, {currency, 'event': event[2]}));
+        });
+        return key;
+    }
+
+    close(){
+        if(this.socket){
+            return this.socket.disconnect();
+        }
+    }
+}
+
+module.exports = LiveOrderStream;


### PR DESCRIPTION
Bitstamp websocket API also exposes live_orders with order_created, order_changed, order_deleted events. This live_orders stream needs to be implemented in the node-bitstamp library. This change implements the same.