### PR TITLE
Preserve error object when rejecting promise due to API response.

### DIFF
--- a/lib/Bitstamp.js
+++ b/lib/Bitstamp.js
@@ -95,7 +95,7 @@ class Bitstamp {
                 if (error){
                     return reject(error);
                 }
-                
+
                 // The HTTP request worked but returned an error code.
                 // e.g. 401 unauthorized
                 if (response.statusCode < 200 || response.statusCode > 299) {
@@ -113,17 +113,17 @@ class Bitstamp {
                 } catch (error) {
                     return reject(error);
                 }
-                
+
                 // There was an API request error.
                 // e.g. Insufficient funds in case of withdrawal.
                 if (body.status === "error") {
-                    return reject(new Error(body.reason));
+                    return reject(body.reason);
                 }
-                
+
                 // Typically this happens when the request's statuscode
                 // is not 2xx but we check here just in case.
                 if (body.error) {
-                    return reject(new Error(body.error));
+                    return reject(body.error);
                 }
 
                 resolve({
@@ -339,7 +339,7 @@ class Bitstamp {
     }
 
     bchWithdrawal(amount, address){
-        
+
         const ep = "bch_withdrawal";
         const body = {
             amount,


### PR DESCRIPTION
Fixes #25

![screenshot 2018-12-03 at 15 45 24](https://user-images.githubusercontent.com/14090872/49384232-7d645700-f712-11e8-9c25-5424253c79c3.png)

