### PR TITLE
added btc usd pair and instant order buy and sell

### DIFF
--- a/lib/Bitstamp.js
+++ b/lib/Bitstamp.js
@@ -256,6 +256,24 @@ class Bitstamp {
         return this.call(this._resolveEP(ep, currency), HTTP_METHOD.POST, body, true);
     }
 
+    buyInstantOrder(amount , currency = null){
+        const ep = "buy/instant";
+        const body = {
+            amount
+        }
+        return this.call(this._resolveEP(ep, currency), HTTP_METHOD.POST, body, true );
+    }
+
+    sellInstantOrder( amount, currency =null){
+        const ep = "sell/instant";
+        const body = {
+            amount
+        }
+        return this.call(this._resolveEP(ep, currency), HTTP_METHOD.POST, body, true );
+    }
+
+
+
     sellLimitOrder(amount, price, currency = null, limit_price = null, daily_order = null){
 
         const ep = "sell";

--- a/lib/currency.js
+++ b/lib/currency.js
@@ -2,6 +2,7 @@
 
 const CURRENCY = {
     BTC_EUR: "btceur",
+    BTC_USD: "btcusd",
     EUR_USD: "eurusd",
     XRP_USD: "xrpusd",
     XRP_EUR: "xrpeur",


### PR DESCRIPTION
Added method to buy an instant order or sell an instant order. solves #32 