### PR TITLE
Add support for GBP, PAX and XLM

### DIFF
--- a/lib/Bitstamp.js
+++ b/lib/Bitstamp.js
@@ -187,7 +187,7 @@ class Bitstamp {
     conversionRate(){
 
         const ep = "eur_usd";
-        return this.call(this._resolveEP(ep, null), HTTP_METHOD.GET, null, false);
+        return this.call(this._resolveEP(ep, null), HTTP_METHOD.GET, null, false, true);
     }
 
     /* PRIVATE */

--- a/lib/currency.js
+++ b/lib/currency.js
@@ -1,18 +1,38 @@
 "use strict";
 
 const CURRENCY = {
-    BTC_EUR: "btceur",
     BTC_USD: "btcusd",
+    BTC_EUR: "btceur",
+    BTC_GBP: "btcgbp",
+    BTC_PAX: "btcpax",
+    GBP_USD: "gbpusd",
+    GBP_EUR: "gbpeur",
     EUR_USD: "eurusd",
     XRP_USD: "xrpusd",
     XRP_EUR: "xrpeur",
     XRP_BTC: "xrpbtc",
+    XRP_GBP: "xrpgbp",
+    XRP_PAX: "xrppax",
     LTC_USD: "ltcusd",
     LTC_EUR: "ltceur",
     LTC_BTC: "ltcbtc",
+    LTC_GBP: "ltcgbp",
     ETH_USD: "ethusd",
     ETH_EUR: "etheur",
-    ETH_BTC: "ethbtc"
+    ETH_BTC: "ethbtc",
+    ETH_GBP: "ethgbp",
+    ETH_PAX: "ethpax",
+    BCH_USD: "bchusd",
+    BCH_EUR: "bcheur",
+    BCH_BTC: "bchbtc",
+    BCH_GBP: "bchgbp",
+    PAX_USD: "paxusd",
+    PAX_EUR: "paxeur",
+    PAX_GBP: "paxgbp",
+    XLM_BTC: "xlmbtc",
+    XLM_USD: "xlmusd",
+    XLM_EUR: "xlmeur",
+    XLM_GBP: "xlmgbp",
 };
 
 module.exports = CURRENCY;


### PR DESCRIPTION
Hello,

this PR adds support for current markets available on Bitstamp as per https://www.bitstamp.net/api-internal/market/pairs/

The PR also includes a commit which fixes the call to eur_usd conversion rate as it's only available on api v1 (https://www.bitstamp.net/api/eur_usd/)